### PR TITLE
Fix icons for Ant Design v4

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import stylesheet from 'antd/dist/antd.min.css'
 
-import { Layout, Menu, Breadcrumb, Icon } from 'antd';
+import { Layout, Menu, Breadcrumb } from 'antd';
+import { UserOutlined, LaptopOutlined, NotificationOutlined } from '@ant-design/icons';
 
 const { SubMenu } = Menu;
 const { Header, Content, Sider } = Layout;
@@ -42,19 +43,19 @@ export default class App extends React.Component {
             defaultOpenKeys={['sub1']}
             style={{ height: '100%' }}
           >
-            <SubMenu key="sub1" title={<span><Icon type="user" />subnav 1</span>}>
+            <SubMenu key="sub1" icon={<UserOutlined />} title="subnav 1">
               <Menu.Item key="1">option1</Menu.Item>
               <Menu.Item key="2">option2</Menu.Item>
               <Menu.Item key="3">option3</Menu.Item>
               <Menu.Item key="4">option4</Menu.Item>
             </SubMenu>
-            <SubMenu key="sub2" title={<span><Icon type="laptop" />subnav 2</span>}>
+            <SubMenu key="sub2" icon={<LaptopOutlined />} title="subnav 2">
               <Menu.Item key="5">option5</Menu.Item>
               <Menu.Item key="6">option6</Menu.Item>
               <Menu.Item key="7">option7</Menu.Item>
               <Menu.Item key="8">option8</Menu.Item>
             </SubMenu>
-            <SubMenu key="sub3" title={<span><Icon type="notification" />subnav 3</span>}>
+            <SubMenu key="sub3" icon={<NotificationOutlined />} title="subnav 3">
               <Menu.Item key="9">option9</Menu.Item>
               <Menu.Item key="10">option10</Menu.Item>
               <Menu.Item key="11">option11</Menu.Item>


### PR DESCRIPTION
## Summary
- update Ant Design icon imports
- use new icon prop in `SubMenu`

## Testing
- `node --version`
- `npm install` *(fails: 403 Forbidden due to network restrictions)*


------
https://chatgpt.com/codex/tasks/task_e_687fbd4f661883259294dd4fef8a81f2